### PR TITLE
ci: don't retrigger workflows after merging into main

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,8 +9,6 @@ on:
   # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
   pull_request_target:
     branches: [ main ]
-  push:
-    branches: [ main ]
   merge_group:
 jobs:
   check:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,6 @@ on:
   # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
   pull_request_target:
     branches: [ main ]
-  push:
-    branches: [ main ]
   merge_group:
 jobs:
   approve:


### PR DESCRIPTION
The merge queue runs the integration with the future main branch so there is no need to rerun the tests/checks