### PR TITLE
ci: publish container image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,59 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  # Wait until all other publishing jobs are finished
+  # before publishing the virtual packages (which are architecture agnostic)
+  publish-containers:
+    name: Publish Containers
+    runs-on: ubuntu-20.04
+    env:
+      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: extractions/setup-just@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=ghcr.io/thin-edge/python-tedge-agent,enable=true
+          tags: |
+            type=raw,value={{tag}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: containers/opcua-device-gateway
+          file: containers/production.dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/containers/agent.dockerfile
+++ b/containers/agent.dockerfile
@@ -1,0 +1,20 @@
+ARG PY_VERSION=3.10
+FROM python:${PY_VERSION} as builder
+WORKDIR /build
+RUN python -m pip install build
+COPY . .
+RUN python -m build --wheel \
+    && pip install dist/*.whl
+
+ARG PY_VERSION=3.10
+FROM python:${PY_VERSION}-slim
+ARG PY_VERSION=3.10
+
+# Copy build artifacts
+COPY --from=builder "/usr/local/lib/python${PY_VERSION}/site-packages" "/usr/local/lib/python${PY_VERSION}/site-packages"
+COPY --from=builder /usr/local/bin/python-tedge-agent /usr/local/bin/
+
+ENV CONNECTOR_TEDGE_HOST=mqtt-broker
+ENV CONNECTOR_TEDGE_API=http://tedge:8000
+
+CMD ["python-tedge-agent"]

--- a/containers/demo.dockerfile
+++ b/containers/demo.dockerfile
@@ -14,7 +14,6 @@ ARG PY_VERSION=3.10
 COPY --from=builder "/usr/local/lib/python${PY_VERSION}/site-packages" "/usr/local/lib/python${PY_VERSION}/site-packages"
 COPY --from=builder /usr/local/bin/python-tedge-agent /usr/local/bin/
 
-#COPY config/tedge-configuration-plugin.json /config
 COPY config/*.json /data/config/
 
 ENV CONNECTOR_TEDGE_HOST=mqtt-broker

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
   child01:
     build:
       context: .
-      dockerfile: ./images/child.dockerfile
+      dockerfile: ./containers/demo.dockerfile
       args:
         - PY_VERSION=${PY_VERSION:-3.11}
     environment:


### PR DESCRIPTION
Publish a container image so that it can be used by other projects (e.g. the tedge-demo-container repo)