### PR TITLE
ci: remove dynamic wait as the bootstrap extension waits internally

### DIFF
--- a/ci/demo.sh
+++ b/ci/demo.sh
@@ -6,28 +6,8 @@ just prepare-up
 just up --build=false >/dev/null 2>&1 &
 UP_PID=$!
 
-# Wait for bootstrap service to 
-COUNTER=1
-TIMEOUT=60
-BOOTSTRAP=1
-if [ "$(docker compose ps tedge -a --format '{{.State}}')" != "running" ]; then
-    while [ "$(docker compose ps bootstrap -a --format '{{.State}}')" != "running" ]; do
-        if [ "$COUNTER" -ge "$TIMEOUT" ]; then
-            echo "Timed out waiting for bootstrap service to be ready" >&2
-            exit 1
-        fi
-        echo "bootstrap service not running...attempt $COUNTER" >&2
-        sleep 1
-        COUNTER=$((COUNTER + 1))
-    done
-else
-    echo "tedge service is already running (bootstrapping was probably already done)" >&2
-    BOOTSTRAP=0
-fi
-
-if [ "$BOOTSTRAP" = 1 ]; then
-    just bootstrap "$DEVICE_ID" </dev/null
-fi
+# Note: bootstrap will wait for the container to be ready
+just bootstrap "$DEVICE_ID" </dev/null
 
 # Wait until bootstrap is ready
 wait "$UP_PID"


### PR DESCRIPTION
Remove log to wait for the bootstrapping container to be ready as the c8y-tedge extension handles this. It also skips bootstrapping if bootstrapping was already done.